### PR TITLE
Fixed eval_ckpt_idx unresolved reference error

### DIFF
--- a/occant_baselines/rl/occant_nav_trainer.py
+++ b/occant_baselines/rl/occant_nav_trainer.py
@@ -472,7 +472,7 @@ class OccAntNavTrainer(BaseRLTrainer):
 
         if checkpoint_index == 0:
             try:
-                checkpoint_index = self.config.EVAL_CKPT_PATH_DIR.split("/")[-1].split(
+                eval_ckpt_idx = self.config.EVAL_CKPT_PATH_DIR.split("/")[-1].split(
                     "."
                 )[1]
                 logger.add_filehandler(


### PR DESCRIPTION
Changed `checkpoint_index` variable name to `eval_ckpt_idx` to fix the unresolved reference error.

See https://github.com/facebookresearch/OccupancyAnticipation/issues/6 for more details.